### PR TITLE
feat(args): add `--version` flag

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -2,6 +2,7 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 
 #[derive(Debug, clap::Parser)]
+#[clap(version)]
 pub struct Args {
     /// The directory to read UTF-8 encoded text files from.
     #[clap(long, short = 'i', default_value = "input", help_heading = "INPUT")]


### PR DESCRIPTION
This commit adds `version` to the clap derive struct and makes it possible to display the CLI version via `--version`.

Closes #21

