### PR TITLE
Split comma-separated `--ignore-extension` arguments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::bail;
 use prodash::Progress;
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -35,7 +35,12 @@ pub fn unicode_content(
         let path = entry.path();
         if !ignore_extensions.is_empty()
             && path.extension().map_or(false, |ext| {
-                ignore_extensions.iter().any(|extension| ext == extension)
+                ignore_extensions.iter().flat_map(|ext| match ext.to_str() {
+                    Some(ext) => {
+                        ext.split(',').map(OsStr::new).collect()
+                    },
+                    None => vec![ext.as_os_str()],
+                }).any(|extension| ext == extension)
             })
         {
             ignored += 1;


### PR DESCRIPTION
Allows using a single --ignore-extension argument to ignore multiple extensions.
- Use like: `codevis -i ./ --ignore-extension md,toml,lock`

Useful when you need to ignore a lot of different extensions.

Here's a command I used today:
`codevis -i ./ --ignore-files-without-syntax --ignore-extension asmdef --ignore-extension meta --ignore-extension shader --ignore-extension mat --ignore-extension asset --ignore-extension prefab --ignore-extension txt --ignore-extension svg`
This pull request would simplify this down to:
`codevis -i ./ --ignore-files-without-syntax --ignore-extension asmdef,meta,shader,mat,asset,prefab,txt,svg`

Notes for maintainers:
I am a novice Rust programmer, and am very much still learning. If this is not a good way of implementing this change, feel free to reject, and if you have time, please let me know what is wrong.