### PR TITLE
chore(cargo): update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "codevis"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bstr 1.0.1",


### PR DESCRIPTION
The version was updated in 481b335a95bb27a0a6c2906d8b19e05a387752b4 but Cargo.lock wasn't.
