### PR TITLE
chore(ci): build with `--locked` flag

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: Swatinem/rust-cache@v2
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --locked --verbose
     - name: Run tests
       run: cargo test --verbose


### PR DESCRIPTION
This PR updates continuous integration workflow for building/testing with '--locked' flag which means Cargo.lock should be up-to-date thus issues like #43 can be spotted early in the development phase.
